### PR TITLE
edit README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ configuration path is usually `~/.config` as specified by
 Do an `echo $XDG_CONFIG_HOME` to ensure that it is not empty. If it is empty,
 replace `$XDG_CONFIG_HOME` with `~/.config` path in the commands below.
 ```bash
-mkdir -p ~/scripts/pathfinder
-cd ~/scripts/pathfinder
+cd ~/scripts
 git clone https://github.com/gokuldas/pathfinder pathfinder
 mkdir -p $XDG_CONFIG_HOME/pathfinder
 cp ~/scripts/pathfinder/src/pathfinder.toml $XDG_CONFIG_HOME/pathfinder


### PR DESCRIPTION
`git clone URL PATH` should create a new directory if it does not exist. 

If you instead create a new directory with the same name, there will be two directories with the same name, which I think is not what is intended by reading below the changed lines.